### PR TITLE
Prevent null error when $row['subgroup'] does not exist

### DIFF
--- a/Classes/EventListener/ModifyResolvedFrontendGroups.php
+++ b/Classes/EventListener/ModifyResolvedFrontendGroups.php
@@ -56,7 +56,7 @@ class ModifyResolvedFrontendGroups
                         )
                     )
                     ->execute();
-                while ($row = $res->fetchAssociative()) {
+                while ($row = $res->fetch()) {
                     $allGroups[$row['uid']] = $row;
                 }
             }
@@ -115,7 +115,7 @@ class ModifyResolvedFrontendGroups
         // Internal group record storage
         $groupRows = [];
         // The groups array is filled
-        while ($row = $res->fetchAssociative()) {
+        while ($row = $res->fetch()) {
             if (!in_array($row['uid'], $groups)) {
                 $groups[] = $row['uid'];
             }

--- a/Classes/EventListener/ModifyResolvedFrontendGroups.php
+++ b/Classes/EventListener/ModifyResolvedFrontendGroups.php
@@ -130,7 +130,7 @@ class ModifyResolvedFrontendGroups
             // Must be an array and $uid should not be in the idList, because then it is somewhere previously in the grouplist
             if (is_array($row) && !GeneralUtility::inList($idList, $uid)) {
                 // Include sub groups
-                if (array_key_exists('subgroup', $row)) {
+                if (array_key_exists('subgroup', $row) && $row['subgroup'] !== '') {
                     // Make integer list
                     $theList = implode(',', GeneralUtility::intExplode(',', $row['subgroup']));
                     // Call recursively, pass along list of already processed groups so they are not processed again.

--- a/Classes/EventListener/ModifyResolvedFrontendGroups.php
+++ b/Classes/EventListener/ModifyResolvedFrontendGroups.php
@@ -130,7 +130,7 @@ class ModifyResolvedFrontendGroups
             // Must be an array and $uid should not be in the idList, because then it is somewhere previously in the grouplist
             if (is_array($row) && !GeneralUtility::inList($idList, $uid)) {
                 // Include sub groups
-                if (trim($row['subgroup'])) {
+                if (array_key_exists('subgroup', $row)) {
                     // Make integer list
                     $theList = implode(',', GeneralUtility::intExplode(',', $row['subgroup']));
                     // Call recursively, pass along list of already processed groups so they are not processed again.

--- a/Classes/EventListener/ModifyResolvedFrontendGroups.php
+++ b/Classes/EventListener/ModifyResolvedFrontendGroups.php
@@ -56,7 +56,7 @@ class ModifyResolvedFrontendGroups
                         )
                     )
                     ->execute();
-                while ($row = $res->fetch()) {
+                while ($row = $res->fetchAssociative()) {
                     $allGroups[$row['uid']] = $row;
                 }
             }
@@ -115,7 +115,7 @@ class ModifyResolvedFrontendGroups
         // Internal group record storage
         $groupRows = [];
         // The groups array is filled
-        while ($row = $res->fetch()) {
+        while ($row = $res->fetchAssociative()) {
             if (!in_array($row['uid'], $groups)) {
                 $groups[] = $row['uid'];
             }


### PR DESCRIPTION
- Prevent error `Argument #1 ($string) must be of type string, null given` (tested with PHP 8.1)https://github.com/b13/sessionpassword/blob/22bbe04695b00c05bb1148e2372d196acc00ef75/Classes/EventListener/ModifyResolvedFrontendGroups.php#L133

- Replace fetch() with fetchAssociative() - but just in this file, seemed like an easy improvement 

